### PR TITLE
fix(docker): add --no-install-project to the dev stage's first uv sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,14 @@ FROM base AS dev
 
 WORKDIR /workspace
 
+# --no-install-project: only uv.lock / pyproject.toml are mounted in this layer, so
+# building the project itself fails (missing README.md / sources) once a derived
+# project becomes a package (`package = true`). The project is installed by the
+# second uv sync below, after COPY.
 RUN --mount=type=cache,target=/root/.cache/uv \
   --mount=type=bind,source=uv.lock,target=uv.lock \
   --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-  uv sync --frozen
+  uv sync --frozen --no-install-project
 
 COPY . /workspace
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
## Changes

The dev stage's first `uv sync --frozen` mounts only `uv.lock` / `pyproject.toml`. That works while this template stays a virtual (non-package) project, but as soon as a derived project becomes a package (`[tool.uv] package = true` + a build backend — the natural next step when adding a CLI entry point), uv tries to build the project inside that layer and hatchling fails on the missing `README.md` / sources:

```
OSError: Readme file does not exist: README.md
```

Worse, layer caching hides the breakage: it only surfaces on a fresh build (`--build-no-cache`, new machine, CI), potentially long after the packaging change landed. This bit hanamizuno/jiritsu#61 two weeks after the fact.

Adding `--no-install-project` makes the first layer resolve dependencies only; the project itself is installed by the second `uv sync` after `COPY`. This:

- is a no-op for the template as-is (virtual project — nothing to install either way)
- mirrors the prod stage, which already uses `--no-install-project --no-dev`
- matches the upstream [uv-docker-example](https://github.com/astral-sh/uv-docker-example) referenced at the top of the Dockerfile

## How to test

Reproduced the derived-project failure against a copy of this repo made into a package (`[build-system]` hatchling + `[tool.uv] package = true` + `[tool.hatch.build.targets.wheel] packages = ["myapp"]`, then `uv lock`):

- **without this fix**: `docker buildx build --target dev` fails in the first sync layer with the `OSError` above
- **with this fix**: all stages build, and `docker run --rm <img> python -c "import myapp"` confirms the second sync still installs the project

On the template itself: `dev` / `prod` / `devcontainer` targets all build, hadolint is clean, and `task lint` / `task test` pass.

## Requirements

## Related issues

Surfaced in hanamizuno/jiritsu#61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)