### PR TITLE
ci: auto-label harness-change PRs with the meta label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+# Configuration for actions/labeler (run by .github/workflows/label_pr.yml).
+# Labels PRs that modify the development harness (agent instructions, CI,
+# containers, tooling config) rather than application code.
+#
+# Note: the labeler's `dot` option defaults to true, so globs match
+# dot-directories like .github/ and .devcontainer/ without special handling.
+# Deliberately excluded: .python-version, uv.lock (routine dependency churn).
+
+meta:
+  - changed-files:
+      - any-glob-to-any-file:
+          # Agent / contributor instructions
+          - "AGENTS.md"
+          - "CLAUDE.md"
+          # GitHub config (workflows, templates, copilot-instructions.md, this file)
+          - ".github/**"
+          # Containers
+          - "Dockerfile"
+          - ".dockerignore"
+          - "compose.yml"
+          - "compose.dev.yml"
+          - ".devcontainer/**"
+          # Tooling / editor config (ruff, pyright, pytest, taskipy live in pyproject.toml)
+          - "pyproject.toml"
+          - ".editorconfig"
+          - ".vscode/**"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -31,3 +31,9 @@
 - name: "wontfix"
   color: "ffffff"
   description: "This will not be worked on"
+
+# --- Project-specific labels (beyond GitHub defaults) ---
+
+- name: "meta"
+  color: "6e7781"
+  description: "Changes to the development harness (CI, containers, agent instructions, tooling config)"

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -1,0 +1,32 @@
+name: Label PRs
+
+on:
+  pull_request:
+    branches: [main]
+    # Default types, made explicit. `edited` is deliberately excluded:
+    # title/body edits don't change the file set.
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+    # GITHUB_TOKEN is read-only on PRs from forks, so labeling would fail with 403.
+    # We use `pull_request` (not `pull_request_target`, flagged by zizmor as a
+    # dangerous trigger) and accept that fork PRs go unlabeled.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply path-based labels
+        # No checkout needed: labeler reads .github/labeler.yml via the API
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          sync-labels: true

--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ cf. https://zenn.dev/dajiaji/articles/47164ff27d2123
 │   ├── copilot-instructions.md # Pointer to AGENTS.md for GitHub Copilot
 │   ├── dependabot.yml          # Dependabot configuration
 │   ├── ISSUE_TEMPLATE/         # Issue forms (bug, feature, task)
+│   ├── labeler.yml             # Path-based PR labeling config (used by label_pr.yml)
 │   ├── labels.yml              # Repository label definitions (synced by CI)
 │   ├── PULL_REQUEST_TEMPLATE.md
 │   ├── scripts/
 │   │   └── sync-labels.sh
 │   └── workflows/              # GitHub Actions CI workflows
+│       ├── label_pr.yml        # PR auto-labeling (actions/labeler)
 │       ├── labels.yml          # Label sync
 │       ├── lint.yml
 │       ├── lint_docker.yml


### PR DESCRIPTION
## Changes

- Add `.github/labeler.yml` — path config for `actions/labeler`: PRs touching the development harness (agent instruction files, `.github/**`, Docker/devcontainer files, tooling/editor config incl. `pyproject.toml`) get the `meta` label. `.python-version` and `uv.lock` are deliberately excluded (routine dependency churn).
- Add `.github/workflows/label_pr.yml` — runs `actions/labeler` v6.1.0 (SHA-pinned) on `pull_request` with minimal permissions (`contents: read`, `pull-requests: write`), no checkout, `sync-labels: true` so the label is removed if a PR stops touching harness files. Uses `pull_request` instead of the README-recommended `pull_request_target` because zizmor flags the latter as a dangerous trigger; fork PRs are skipped via a same-repo guard by design.
- Add the `meta` label definition to `.github/labels.yml` (created via the existing sync mechanism; already bootstrapped on the repo so this PR can label itself).
- Document the two new files in the README directory tree.

## How to test

- `Lint Github Actions` (actionlint + zizmor) is green on this PR — also verified locally with the same pins (`uvx zizmor@1.26.1 .`, `rhysd/actionlint:1.7.7`): no findings.
- The `Label PRs` check on this PR applies `meta` to it (it touches `.github/**`).
- `Sync Labels` DRY_RUN log shows `unchanged: meta` (label pre-created).
- After merge: a PR touching only `AGENTS.md` gets `meta`; a PR touching only `myapp/` does not; reverting the harness change on a PR removes the label (`sync-labels: true`).

## Requirements

N/A

## Related issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)