### PR TITLE
fix(devcontainer): prek キャッシュ作成の Permission denied を修正

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 # .venv and the uv cache are named volumes that mask the host bind mount
 # (platform-specific binaries must not be shared between host and container).
-# Named volumes are created root-owned on first use, so fix ownership first
-# (a no-op on subsequent creates).
-sudo chown vscode:vscode /workspace/.venv "$HOME/.cache/uv"
+# Named volumes are created root-owned on first use — including the parent
+# ~/.cache that Docker creates for the mountpoint, which prek also needs for
+# its own cache — so fix ownership first (a no-op on subsequent creates).
+sudo chown vscode:vscode /workspace/.venv "$HOME/.cache" "$HOME/.cache/uv"
 
 uv sync --frozen
 


### PR DESCRIPTION
## 目的

#131 で prek pre-commit フックを導入した後、devcontainer を再ビルドすると postCreateCommand が失敗する問題を修正する。

```
error: failed to create directory `/home/vscode/.cache/prek`: Permission denied (os error 13)
postCreateCommand from devcontainer.json failed with exit code 2.
```

## 原因

`uv-cache` ボリュームをマウントする際、マウントポイントの親ディレクトリ `~/.cache` を Docker が root 所有で作成する (Dockerfile の devcontainer ステージは `.claude` 等は事前作成しているが `.cache` はしていない)。post-create.sh の chown は `~/.cache/uv` しか直さないため、`prek install` が自身のキャッシュ `~/.cache/prek` を作成できず失敗する。

## 変更内容

- post-create.sh の chown 対象に `$HOME/.cache` (非再帰) を追加

## テスト方法

- `bash -n .devcontainer/post-create.sh` で構文確認済み
- devcontainer を再ビルドし、postCreateCommand が最後まで完走する (prek install まで到達しエラーが出ない) ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)